### PR TITLE
Add WiP arrow throw effect for normal attacks and add configuration for Skill Actions

### DIFF
--- a/src/DB/Effects/EffectTable.js
+++ b/src/DB/Effects/EffectTable.js
@@ -9460,6 +9460,23 @@ define(function( require )
             attachedEntity: true
         }],
 
-
+        'ef_throw_arrow': [{ // effect to show the thrown arrow (normal attack or skill with a bow)
+            type: '3D',
+            alphaMax: 1,
+            attachedEntity: true,
+            duration: 140,
+            fadeIn: false,
+            fadeOut: false,
+            spriteName: 'skel_archer_arrow',
+            playSprite: true,
+            toSrc: true,
+            rotateToTarget: true,
+            rotateWithCamera: true,
+            posz: 1,
+            size: 1,
+            yOffset: 0.50,
+            xOffset: 0.30,
+            zIndex: 1
+        }]
     };
 });

--- a/src/DB/Skills/SkillEffect.js
+++ b/src/DB/Skills/SkillEffect.js
@@ -74,7 +74,7 @@ define(['./SkillConst'], function( SK )
 	SkillEffect[SK.MC_MAMMONITE]                   = {effectId: 10};		//Mammonite
 	// Archer
 	SkillEffect[SK.AC_CONCENTRATION]               = {effectId: 153};		//Improve Concentration
-	SkillEffect[SK.AC_DOUBLE]                      = {};		//Double Strafe
+	SkillEffect[SK.AC_DOUBLE]                      = {effectId: 'ef_throw_arrow'};		//Double Strafe
 	SkillEffect[SK.AC_SHOWER]                      = {};		//Arrow Shower
 	// Thief
 	SkillEffect[SK.TF_STEAL]                       = {hitEffectId: 18};		//Steal
@@ -379,7 +379,7 @@ define(['./SkillConst'], function( SK )
 	// Sniper
 	SkillEffect[SK.SN_SIGHT]                       = {effectId: 386};		//Falcon Eyes
 	SkillEffect[SK.SN_FALCONASSAULT]               = {effectId: 387};		//Falcon Assault
-	SkillEffect[SK.SN_SHARPSHOOTING]               = {effectId: 388};		//Focused Arrow Strike
+	SkillEffect[SK.SN_SHARPSHOOTING]               = {hitEffectId: 388, effectId: 'ef_throw_arrow', beforeCastEffectId: '496_beforecast'};		//Focused Arrow Strike
 	SkillEffect[SK.SN_WINDWALK]                    = {effectId: 389};		//Wind Walker
 	// Whitesmith
 	SkillEffect[SK.WS_MELTDOWN]                    = {effectId: 390};		//Shattering Strike

--- a/src/DB/Skills/SkillInfo.js
+++ b/src/DB/Skills/SkillInfo.js
@@ -3188,6 +3188,7 @@ define(["./SkillConst", "DB/Jobs/JobConst"], function( SK, JobId )
 		SpAmount: [ 12, 12, 12, 12, 12, 12, 12, 12, 12, 12 ],
 		bSeperateLv: false,
 		AttackRange: [ 9, 9, 9, 9, 9, 9, 9, 9, 9, 9 ],
+		ActionType: "ATTACK3",
 		NeedSkillList: new function() {
 			this[JobId.JT_ROGUE] = [
 				[ SK.AC_VULTURE, 10 ]
@@ -3239,6 +3240,7 @@ define(["./SkillConst", "DB/Jobs/JobConst"], function( SK, JobId )
 		MaxLv: 10,
 		SpAmount: [ 15, 15, 15, 15, 15, 15, 15, 15, 15, 15 ],
 		bSeperateLv: false,
+		ActionType: "ATTACK",
 		AttackRange: [ 9, 9, 9, 9, 9, 9, 9, 9, 9, 9 ],
 		_NeedSkillList: [
 			[ SK.AC_DOUBLE, 5 ]
@@ -4989,6 +4991,7 @@ define(["./SkillConst", "DB/Jobs/JobConst"], function( SK, JobId )
 		Name: "HT_ANKLESNARE",
 		SkillName: "Anklesnare",
 		MaxLv: 5,
+		//ActionType: "PICKUP",
 		SpAmount: [ 12, 12, 12, 12, 12 ],
 		bSeperateLv: true,
 		AttackRange: [ 3, 3, 3, 3, 3 ],
@@ -10461,6 +10464,7 @@ define(["./SkillConst", "DB/Jobs/JobConst"], function( SK, JobId )
 	SkillInfo[SK.SN_SIGHT] = {
 		Name: "SN_SIGHT",
 		SkillName: "True Sight",
+		ActionType: "ACTION",
 		MaxLv: 10,
 		SpAmount: [ 20, 20, 25, 25, 30, 30, 35, 35, 40, 40 ],
 		bSeperateLv: true,
@@ -10511,6 +10515,7 @@ define(["./SkillConst", "DB/Jobs/JobConst"], function( SK, JobId )
 		MaxLv: 5,
 		SpAmount: [ 18, 21, 24, 27, 30 ],
 		bSeperateLv: true,
+		ActionType: "ATTACK3",
 		AttackRange: [ 9, 9, 9, 9, 9 ],
 		_NeedSkillList: [
 			[ SK.AC_DOUBLE, 5 ],

--- a/src/Engine/MapEngine/Entity.js
+++ b/src/Engine/MapEngine/Entity.js
@@ -324,6 +324,11 @@ define(function( require )
 				var weaponSoundLeft = WSndL[0];
 				var weaponSoundReleaseLeft = WSndL[1];
 				
+				// Display throw arrow effect when using bows, not an elegant conditional but it works.. [Waken]
+				if (WSnd[0].includes('bow')) {
+					EffectManager.spam('ef_throw_arrow', dstEntity.GID, null, null, false, srcEntity.GID, srcEntity.position)
+				}
+
 				//attack sound
 				if(weaponSound){
 					Events.setTimeout(function(){
@@ -792,6 +797,22 @@ define(function( require )
 			}
 		}
 
+		var action = (SkillInfo[pkt.SKID] && SkillInfo[pkt.SKID].ActionType) || 'SKILL';
+
+		srcEntity.setAction({
+			action: srcEntity.ACTION[action],
+			frame:  0,
+			repeat: false,
+			play:   true,
+			next: {
+				action: srcEntity.ACTION.IDLE,
+				frame:  0,
+				repeat: false,
+				play:   false,
+				next:   false
+			}
+		});
+
 		if (dstEntity) {
 			if (srcEntity && dstEntity !== srcEntity) {
 				srcEntity.lookTo( dstEntity.position[0], dstEntity.position[1] );
@@ -1014,21 +1035,24 @@ define(function( require )
 			return;
 		}
 
-		if (pkt.delayTime) {
-            if(pkt.SKID != 62) { // Bowling Bash got cast but original client hide it for unknown reason
-                Sound.play('effect/ef_beginspell.wav');
-                srcEntity.cast.set( pkt.delayTime );
-            }
+		if(pkt.delayTime) { // Bowling Bash got cast but original client hide it for unknown reason
+			if (pkt.SKID != 62) {
+				Sound.play('effect/ef_beginspell.wav');
+				srcEntity.cast.set( pkt.delayTime );
+			}
 
-            if (srcEntity.objecttype === Entity.TYPE_PC) { //monsters don't use ACTION.SKILL animation
-                srcEntity.setAction({
-                    action: srcEntity.ACTION.SKILL,
-                    frame:  0,
-                    repeat: false,
-                    play:   false
-                });
-            }
-        }
+			if (srcEntity.objecttype === Entity.TYPE_PC) { //monsters don't use ACTION.SKILL animation
+				var action = (SkillInfo[pkt.SKID] && SkillInfo[pkt.SKID].ActionType) || 'SKILL';
+		
+				srcEntity.setAction({
+					action: srcEntity.ACTION[action],
+					frame:  0,
+					repeat: false,
+					play: false,
+				});
+			}
+		}
+
 
         // Hardcoded version of Auto Counter casting bar
         // It's dont gey any delayTime so we need to handle it diffrent:

--- a/src/Renderer/Effects/ThreeDEffect.js
+++ b/src/Renderer/Effects/ThreeDEffect.js
@@ -129,6 +129,13 @@ function (WebGL, Client, SpriteRenderer, EntityManager, Altitude) {
             this.posxEnd = 0;
             this.posyStart = otherPosition[1] - position[1];
             this.posyEnd = 0;
+
+            if (effect.xOffset !== undefined) {
+                this.posxStart = (otherPosition[0] - position[0]) + effect.xOffset;
+            }
+            if (effect.yOffset !== undefined) {
+                this.posyStart = (otherPosition[1] - position[1]) + effect.yOffset;
+            }
         }
         if (effect.size) {
             this.sizeStartX = effect.size;
@@ -236,6 +243,12 @@ function (WebGL, Client, SpriteRenderer, EntityManager, Altitude) {
             } else if (this.spriteName) {
                 this.spriteRessource = Client.loadFile('data/sprite/\xc0\xcc\xc6\xd1\xc6\xae/' + this.spriteName + '.spr');
                 this.actRessource = Client.loadFile('data/sprite/\xc0\xcc\xc6\xd1\xc6\xae/' + this.spriteName + '.act');
+
+                // Didn't found the arrow sprite in the spr effects folder [Waken]
+                if (this.spriteName == 'skel_archer_arrow'){
+                    this.spriteRessource = Client.loadFile('data/sprite/npc/' + this.spriteName + '.spr');
+                    this.actRessource = Client.loadFile('data/sprite/npc/' + this.spriteName + '.act');
+                }
             }
         }
 		


### PR DESCRIPTION
- Add first arrow throw implementation as the video shown : 

https://i.gyazo.com/8a1ea76a85f70f8e74c71fb1438e8ad4.mp4

Note: Maybe it needs some adjustments, for example we need to change the effect start position to be near the Bow, no matter the character position.

- It adds logic to define specific skill actions in skills table (that doesn't dependent on what effect uses) useful for basic skill actions and... some effects doesn't necessarily should have actions defined in the effect itself.