### PR TITLE
Warp not being correctly displayed sometimes

### DIFF
--- a/src/Renderer/Map/Effects.js
+++ b/src/Renderer/Map/Effects.js
@@ -93,15 +93,15 @@ function(        glMatrix,            EffectManager)
 				if(mapEffect.id in EffectDB){
 					var effect = EffectDB[mapEffect.id];
 
-					for (var i = 0, count = effect.length; i < count; ++i) {
+					for (var j = 0; j < effect.length; ++j) {
 						//var dupli = effect[i].duplicate;  // duplicate handling. Not needed for now.
 
 						//for (var j = 0; j <= dupli ; ++j) {
 
-							if(mapEffect.param[0]) effect[i].size       = 100 * mapEffect.param[0]; //size
-							if(mapEffect.param[1]) effect[i].delayFrame = 100 / (1+mapEffect.param[1]); // animspeed
+							if(mapEffect.param[0]) effect[j].size       = 100 * mapEffect.param[0]; //size
+							if(mapEffect.param[1]) effect[j].delayFrame = 100 / (1+mapEffect.param[1]); // animspeed
 
-							EffectManager.spamEffect(effect[i], mapEffect.name+'-'+i, 0, mapEffect.pos, 0, tick, false, null);
+							EffectManager.spamEffect(effect[j], mapEffect.name+'-'+j, 0, mapEffect.pos, 0, tick, false, null);
 						//}
 					}
 


### PR DESCRIPTION
I had an issue where warps were supposed to be displayed but wasn't in some cases. 
After running debugger, i figured out that some variable were shadowed leading to [main loop ](https://github.com/MrAntares/Ragna.roBrowser/blob/master/src/Renderer/Map/Effects.js#L78) not being completed, and thus some effect not displayed.

It is weird that this issue has not been raised before, so if it is working perfectly fine for anyone, feel free to discard this PR