### PR TITLE
fixed - player not attack after reached the target

### DIFF
--- a/src/Controls/MapControl.js
+++ b/src/Controls/MapControl.js
@@ -91,7 +91,7 @@ define(function( require )
 	{
 		var action = event && event.which || 1;
 
-		Session.moveAction = null;
+		
 
 		if (!Mouse.intersect) {
 			return;
@@ -104,6 +104,7 @@ define(function( require )
 
 			// Left click
 			case 1:
+				Session.moveAction = null;
 				var stop        = false;
 				if(entityOver != Session.Entity){
 					if (entityFocus && entityFocus != entityOver) {


### PR DESCRIPTION
when the player locked the target and the character is moving but the player rotates the camera or resets the camera, so, when the player reached the monster they will do nothing.
the problem issue is in the MapEngine.js -> onMouseDown()
whenever and whatever player clicks (left and right it will set the Session.moveAction to null)
I think this should not happen when the player clicks the right mouse

(cherry picked from commit 4dd25172afa808809f98d0b41da0a9bfc93f0e3f)