### PR TITLE
Fix move packet sent twice when click on warp

### DIFF
--- a/src/Controls/EntityControl.js
+++ b/src/Controls/EntityControl.js
@@ -186,7 +186,7 @@ define(function( require )
 				pkt.dest[0] = this.position[0];
 				pkt.dest[1] = this.position[1];
 				Network.sendPacket(pkt);
-				break;
+				return true;
 		}
 
 		return false;


### PR DESCRIPTION
Move packet used to be sent twice when player click on a warp entity
It was due because on the "onMouseDown" listener attached to warp entity was returning false, then in MapControl.js the "stop" flag was set to false, leading to mouse down event being propagated to map "onRequestWalk"

## Before the fix
![move_packet_sent_twice](https://user-images.githubusercontent.com/1909074/208506908-afaee97d-d5f1-4ebc-9660-181fd72cc323.png)
## After the fix
![move_packet_sent_once](https://user-images.githubusercontent.com/1909074/208506915-596ab43f-70a0-492c-b055-b9b0d5632eb3.png)

